### PR TITLE
fix 2 bugs

### DIFF
--- a/cn.zh-cn/SDK参考/开始使用-Python.md
+++ b/cn.zh-cn/SDK参考/开始使用-Python.md
@@ -16,8 +16,11 @@
 import time
 from smnsdkcore.client import SMNClient
 from smnsdkrequests.v20171105.SmsPublish import SmsPublish
+import ssl
 
-def demoSendSms(sms_sign_id, endpoint, message):
+ssl._create_default_https_context = ssl._create_unverified_context
+
+def demoSendSms(client, sms_sign_id, endpoint, message):
     request = SmsPublish()
     request.set_endpoint(endpoint)
     request.set_message(message)
@@ -32,7 +35,7 @@ if __name__ == "__main__":
     phoneNumber = '+8618682****29'
     message = '您的验证码是:1234，请查收'
 
-    status, headers, response_body = demoSendSms(sms_sign_id, phoneNumber, message)
+    status, headers, response_body = demoSendSms(client, sms_sign_id, phoneNumber, message)
     print status, response_body
 ```
 
@@ -47,8 +50,11 @@ if __name__ == "__main__":
 
 from smnsdkcore.client import SMNClient
 from smnsdkrequests.v20171105.CreateTopic import CreateTopic
+import ssl
 
-def demoCreateTopic(topic_name, display_name):
+ssl._create_default_https_context = ssl._create_unverified_context
+
+def demoCreateTopic(client, topic_name, display_name):
     request = CreateTopic()
     request.set_topic_name(topic_name)
     request.set_display_name(display_name)
@@ -57,7 +63,7 @@ def demoCreateTopic(topic_name, display_name):
 if __name__ == "__main__":
     client = SMNClient(username='YourAccountUserName', domain_name='YourAccountDomainName', password='YourAccountPassword', region_id='YourRegionName')
 
-    status, headers, response_body = demoCreateTopic('python-sdk', 'FromCloud')
+    status, headers, response_body = demoCreateTopic(client, 'python-sdk', 'FromCloud')
     print status, response_body
 ```
 
@@ -68,8 +74,11 @@ if __name__ == "__main__":
 
 from smnsdkcore.client import SMNClient
 from smnsdkrequests.v20171105.Subscribe import Subscribe
+import ssl
 
-def demoSubscribe(topic_urn, endpoint, remark):
+ssl._create_default_https_context = ssl._create_unverified_context
+
+def demoSubscribe(client, topic_urn, endpoint, remark):
     request = Subscribe()
     request.set_endpoint(endpoint)
     request.set_remark(remark)
@@ -82,7 +91,7 @@ if __name__ == "__main__":
     test_urn = 'urn:smn:cn-north-1:xxxx:python-sdk'
     endpoint_phone = '+8618682****29'
     endpoint_remark = 'this is pengzl phone'
-    status, headers, response_body = demoSubscribe(test_urn, endpoint_phone, endpoint_remark)
+    status, headers, response_body = demoSubscribe(client, test_urn, endpoint_phone, endpoint_remark)
     print status, response_body
 ```
 
@@ -94,8 +103,11 @@ if __name__ == "__main__":
 from smnsdkcore.client import SMNClient
 from smnsdkrequests.v20171105 import Publish
 from smnsdkrequests.v20171105.Publish import PublishMessage
+import ssl
 
-def demoPublishMessage(topic_urn, message):
+ssl._create_default_https_context = ssl._create_unverified_context
+
+def demoPublishMessage(client, topic_urn, message):
     request = PublishMessage()
     request.set_topic_urn(topic_urn)
     request.set_subject("Subject, only display to email subscription")
@@ -109,7 +121,7 @@ if __name__ == "__main__":
     subscription_urn = 'urn:smn:cn-north-1: xxxx:python-sdk:xxxx'
     message = '您的验证码是:1234，请查收'
 
-    status, headers, response_body = demoPublishMessage(test_urn, message)
+    status, headers, response_body = demoPublishMessage(client, test_urn, message)
     print status, response_body
 ```
 


### PR DESCRIPTION
1. 原来的代码直接运行会报SSL证书不受信任的异常，如下：
```
Function invocation catch a 'SSLError' exception([SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590))
Traceback (most recent call last):
  File "./index.py", line 15, in handler
    status, headers, response_body = demoCreateTopic(client, 'python-sdk', 'FromCloud')
  File "./index.py", line 10, in demoCreateTopic
    return client.send(request)
  File "./smnsdkcore/client.py", line 84, in send
    self._set_authentication(smn_request)
  File "./smnsdkcore/client.py", line 102, in _set_authentication
    x_auth_token = self.__authentication.get_x_auth_token()
  File "./smnsdkcore/auth/iam.py", line 137, in get_x_auth_token
    status, headers, body = httpclient.get_https_response()
  File "./smnsdkcore/http/http_client.py", line 99, in get_https_response
    self.__connection.connect()
  File "${PYTHONHOME}/lib/python2.7/httplib.py", line 1278, in connect
  File "${PYTHONHOME}/lib/python2.7/ssl.py", line 353, in wrap_socket
  File "${PYTHONHOME}/lib/python2.7/ssl.py", line 601, in __init__
  File "${PYTHONHOME}/lib/python2.7/ssl.py", line 830, in do_handshake
SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
```
因此添加了一下证书：
```
import ssl

ssl._create_default_https_context = ssl._create_unverified_context
```
2. 给所有的 `demo....`函数加上client参数，增加可移植性
